### PR TITLE
Ability to combine multiple groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # install-group
 
 Dependency grouping for `npm install`
@@ -9,33 +10,33 @@ Dependency grouping for `npm install`
 ## Motivation
 
 - npm no longer auto installs `peerDependencies`
-- npm only recognizes `dependencies`, `devDependencies` and `optionalDependencies`
-- your workflow might require declaring a new type of `Dependencies` that doesn't fit any of the above
-- zero dependencies
+- With `install-group`, you can define and install from custom dependency groups beyond the standard `dependencies`, `devDependencies`, and `optionalDependencies`
+- Supports dynamic dependency groups directly from your `package.json`
+- Zero dependencies
 
 ## How it works
 
-`install-group` simply takes an argument `dependencies`, compares it against your `package.json` and runs `npm install` for any dependency listed under that group using `npm install`
+`install-group` reads your `package.json`, identifies all *Dependencies groups, and can selectively install any combination of these groups or all if no specific group is mentioned.
 
 ### Example
 
-``` bash
+```bash
 install-group [dependencies] --package [name] <options>
 ```
 
-``` bash
-install-group peer --package @ahmadnassri/build-essential --global
+```bash
+install-group dev,peer --package @ahmadnassri/build-essential --global
 ```
 
 ###### executed result
 
-``` bash
+```bash
 npm install --global @ahmadnassri/eslint-config@^1.1.1 @ahmadnassri/remark-config@^1.0.0 @ahmadnassri/semantic-release-config@^1.0.6 editorconfig-checker@^1.3.3 eslint@^5.7.0 install-peerdeps@^1.9.0 node-release-lines@^1.3.1 npm-run-all@^4.1.3 remark-cli@^6.0.0 semantic-release@^15.10.5 updated@^1.1.0
 ```
 
 ## Install
 
-``` bash
+```bash
 npm install install-group
 ```
 
@@ -45,20 +46,20 @@ npm install install-group
 
 ### Usage
 
-``` bash
+```bash
 install-group [dependencies] --package [name] <options>
 ```
 
 | parameter      | required | default | description                                     |
 |----------------|----------|---------|-------------------------------------------------|
-| `dependencies` | ✅       | `-`     | `dependencies` to install from target package   |
+| `dependencies` | ✅       | `-`     | Comma-separated list or single `dependencies` group to install from target package   |
 | `package`      | ❌       | `-`     | package name to pull from npm registry          |
 | `options`      | ❌       | `-`     | list of CLI parameters to pass to `npm install` |
 
 > **Notes**:
 >
-> - if no `--package` parameter is provided, `install-group` will scan local `package.json` file for dependencies
-> - `dependencies` can be **any** value in `package.json` regardless of what `npm` officially supports
+> - if no `--package` parameter is provided, `install-group` will scan the local `package.json` file for all *Dependencies groups
+> - `dependencies` can be **any** value in `package.json` that ends with 'Dependencies', regardless of what `npm` officially supports
 
 ## API
 
@@ -68,28 +69,28 @@ install-group [dependencies] --package [name] <options>
 
 | argument       | required | default         | description                                   |
 |----------------|----------|-----------------|-----------------------------------------------|
-| `dependencies` | ✅       | `prod`          | `dependencies` to install from target package |
+| `dependencies` | ✅       | `prod`          | Comma-separated list or single `dependencies` group to scan from the target package |
 | `package`      | ❌       | `-`             | package name to pull from npm registry        |
 | `cwd`          | ❌       | `process.cwd()` | working directory, path to `package.json`     |
 
 > **Notes**:
 >
-> - if no `package` is provided, `install-group` will scan local `package.json` file at `cwd` for dependencies
-> - `dependencies` can be **any** value in `package.json` regardless of what `npm` officially supports
+> - if no `package` is provided, `install-group` will scan the local `package.json` for all *Dependencies groups
+> - `dependencies` can be **any** value in `package.json` that ends with 'Dependencies', regardless of what `npm` officially supports
 
-``` js
+```js
 const scan = require("install-group");
 
-// scan local package.json
-scan({ dependencies: "foo" });
+// scan local package.json for all *Dependencies
+scan({ dependencies: "dev,optional" });
 
-// scan a package from npm registry
+// scan a package from npm registry for specified dependencies
 scan({ dependencies: "peer", package: "@ahmadnassri/build-essential" });
 ```
 
 ###### result example
 
-``` json
+```json
 [
   "@ahmadnassri/eslint-config@^1.1.1",
   "@ahmadnassri/remark-config@^1.0.0",
@@ -105,8 +106,11 @@ scan({ dependencies: "peer", package: "@ahmadnassri/build-essential" });
 ]
 ```
 
-----
-> Author: [Ahmad Nassri](https://www.ahmadnassri.com/) &bull;
+## Contributors
+
+- [Ahmad Nassri](https://www.ahmadnassri.com/)
+- [Marius Guščius](marius.guscius1@gmail.com)
+
 > Twitter: [@AhmadNassri](https://twitter.com/AhmadNassri)
 
 [license-url]: LICENSE

--- a/index.js
+++ b/index.js
@@ -20,12 +20,6 @@ if (index !== -1) {
 // first argument is the install group
 const dependencies = argv.shift()
 
-// exit early
-if (!dependencies) {
-  console.error('ERROR\tinstall group required')
-  process.exit(1)
-}
-
 // scan and install
 scan({ dependencies, package: name, cwd: process.cwd() })
   .then(packages => install(packages, argv))

--- a/index.js
+++ b/index.js
@@ -18,7 +18,10 @@ if (index !== -1) {
 }
 
 // first argument is the install group
-const dependencies = argv.shift()
+let dependencies
+if (!argv[0].startsWith("-")) {
+  dependencies = argv.shift();
+}
 
 // scan and install
 scan({ dependencies, package: name, cwd: process.cwd() })

--- a/lib/scan.js
+++ b/lib/scan.js
@@ -1,41 +1,33 @@
-const { join } = require('path')
-const { execFile } = require('child_process')
-const { promisify } = require('util')
-const spawn = promisify(execFile)
+const { join } = require('path');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+const spawn = promisify(execFile);
 
 module.exports = async function (options) {
-  let { dependencies, cwd } = options
+  let { cwd, dependencies, package: pkgName } = options;
+  
+  // Retrieve package data from either an npm package or a local package.json
+  let pkg = pkgName
+    ? JSON.parse((await spawn('npm', ['--json', 'show', pkgName], { env: process.env })).stdout)
+    : require(join(cwd, 'package.json'));
 
-  dependencies = options.dependencies || 'prod'
-
-  let pkg
-
-  if (options.package) {
-    // spawn npm command and capture output
-    const { stdout } = await spawn('npm', ['--json', 'show', options.package], { env: process.env })
-
-    pkg = JSON.parse(stdout)
-  } else {
-    pkg = require(join(cwd, 'package.json'))
+  // Collect and filter dependency groups
+  let dependencyGroups = Object.keys(pkg).filter(key => key.endsWith('Dependencies'));
+  if (dependencies) {
+    const requestedGroups = dependencies.split(',').map(dep => dep.trim());
+    dependencyGroups = dependencyGroups.filter(group => requestedGroups.includes(group));
   }
 
-  // fix long alias for devDependencies
-  dependencies = dependencies === 'development' ? 'dev' : dependencies
+  // Aggregate packages from the selected groups using map and filter
+  let packages = dependencyGroups
+    .filter(group => pkg[group]) // Filter out groups that are not in the package.json
+    .flatMap(group => Object.keys(pkg[group]) // Map over each group's keys and flatten
+        .map(name => `${name}@${pkg[group][name]}`)); // Create the package strings
 
-  // fix prod / production dependencies prefix
-  dependencies = ~['prod', 'production'].indexOf(dependencies) ? 'dependencies' : dependencies + 'Dependencies'
-
-  // exit early
-  if (!pkg[dependencies]) {
-    throw new Error(`no matching dependencies: ${dependencies}`)
-  }
-
-  // return install format
-  const packages = Object.keys(pkg[dependencies]).map(name => `${name}@${pkg[dependencies][name]}`)
-
+  // Throw an error if no packages found
   if (packages.length === 0) {
-    throw new Error('no packages found')
+    throw new Error('no packages found');
   }
 
-  return packages
+  return packages;
 }

--- a/lib/scan.js
+++ b/lib/scan.js
@@ -13,7 +13,7 @@ module.exports = async function (options) {
 
   // Collect and filter dependency groups
   let dependencyGroups = Object.keys(pkg).filter(key => key.endsWith('Dependencies'));
-  if (dependencies) {
+  if (dependencies && !dependencies.trim()) {
     const requestedGroups = dependencies.split(',').map(dep => `${dep.trim()}Dependencies`);
     dependencyGroups = dependencyGroups.filter(group => requestedGroups.includes(group));
   }

--- a/lib/scan.js
+++ b/lib/scan.js
@@ -14,7 +14,7 @@ module.exports = async function (options) {
   // Collect and filter dependency groups
   let dependencyGroups = Object.keys(pkg).filter(key => key.endsWith('Dependencies'));
   if (dependencies) {
-    const requestedGroups = dependencies.split(',').map(dep => dep.trim());
+    const requestedGroups = dependencies.split(',').map(dep => `${dep.trim()}Dependencies`);
     dependencyGroups = dependencyGroups.filter(group => requestedGroups.includes(group));
   }
 


### PR DESCRIPTION
Not sure if you will want to merge this or not, but this literally allows consumers to have multiple groups combined, ie:
```
install-group dev,test,xxx
```

One caveat though (at least for my own needs I've dropped `dependencies` completely from package.json and rely instead of name+Dependencies, i.e. prodDependencies, devDependencies, coreDependencies and so on)